### PR TITLE
Fix double right clicking crates.

### DIFF
--- a/src/minecraft/assemblyline/common/block/BlockCrate.java
+++ b/src/minecraft/assemblyline/common/block/BlockCrate.java
@@ -112,10 +112,7 @@ public class BlockCrate extends BlockALMachine
 				// Add items
 				if (side == 1 || (side > 1 && hitY > 0.5) || !entityPlayer.capabilities.isCreativeMode)
 				{
-					if (current != null && (current.getMaxStackSize() > 1 || current.itemID == this.blockID))
-					{
-						this.tryInsert(tileEntity, entityPlayer, allMode);
-					}
+					this.tryInsert(tileEntity, entityPlayer, allMode);
 				}
 				// Remove items
 				else if (side == 0 || (side > 1 && hitY <= 0.5))
@@ -268,10 +265,9 @@ public class BlockCrate extends BlockALMachine
 						success = true;
 					}
 				}
-				return success;
 			}
+			return success;
 		}
-
 		return false;
 	}
 


### PR DESCRIPTION
1) It was not figuring out what to do when holding nothing. tryInsert() handles all that, so I just removed the unnecessary conditional.
2) It was returning prematurely when searching player inventory. The return statement was accidentally inside the loop.
